### PR TITLE
refactor(dotenv): move usage of env variables to runtime config

### DIFF
--- a/components/fsxa/sections/DealerMap.tsx
+++ b/components/fsxa/sections/DealerMap.tsx
@@ -54,7 +54,7 @@ class DealerMap extends FSXABaseSection {
       <div class="w-full screen-height-without-header bg-white">
         <Sections.GoogleMapsSection
           language={this.locale.split('_')[0]}
-          apikey={process.env.FSXA_MAPS_APIKEY as string}
+          apikey={this.$config.FSXA_MAPS_APIKEY as string}
           startLocation={
             this.locations && this.locations.length > 0
               ? {

--- a/docs/modules/ROOT/pages/advanced/custom-api-routes/AccessingOtherProjects.adoc
+++ b/docs/modules/ROOT/pages/advanced/custom-api-routes/AccessingOtherProjects.adoc
@@ -50,8 +50,10 @@ const otherProject = new FSXAApi(FSXAContentMode.PREVIEW, {
 ----
 
 As `mode` `remote` must be selected. The attributes in the `config` must also be filled. We recommend to write this data
-into the `.env` file and then call it with the help of `process.env`. This way there is no danger that important
-data will not be pushed.
+into the `.env` file, import it safely into the app by adding it to `publicRuntimeConfig` or `privateRuntimeConfig`
+within your `nuxt.config.js` (further information here:
+https://nuxtjs.org/docs/configuration-glossary/configuration-runtime-config/), and use it during runtime by accessing
+`$config` prop within components. This way there is no danger that important data will not be pushed.
 
 This data is *not* displayed in the client when the application is running,
 because this code is executed exclusively on the server.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,6 +20,13 @@ const config: NuxtConfig = {
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
   /*
+   ** env variables
+   */
+  publicRuntimeConfig: {
+    FSXA_MAPS_APIKEY: process.env.FSXA_MAPS_APIKEY
+  },
+  privateRuntimeConfig: {},
+  /*
    ** Customize the progress-bar color
    */
   loading: { color: '#fff' },
@@ -49,9 +56,7 @@ const config: NuxtConfig = {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
-    'fsxa-nuxt-module',
-    // Doc: https://github.com/nuxt-community/dotenv-module
-    '@nuxtjs/dotenv'
+    'fsxa-nuxt-module'
   ],
   /*
    ** Axios module configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -5153,22 +5153,6 @@
         }
       }
     },
-    "@nuxtjs/dotenv": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/dotenv/-/dotenv-1.4.1.tgz",
-      "integrity": "sha512-DpdObsvRwC8d89I9mzz6pBg6e/PEXHazDM57DOI1mmML2ZjHfQ/DvkjlSzUL7T+TnW3b/a4Ks5wQx08DqFBmeQ==",
-      "requires": {
-        "consola": "^2.10.1",
-        "dotenv": "^8.1.0"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
-        }
-      }
-    },
     "@nuxtjs/eslint-config": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@nuxt/core": "^2.15.8",
     "@nuxtjs/axios": "^5.13.6",
-    "@nuxtjs/dotenv": "^1.4.0",
     "fsxa-nuxt-module": "^3.5.1",
     "nuxt-start": "^2.15.8"
   },


### PR DESCRIPTION
Env variables are no longer accessible with process.env but can be accessed in the Nuxt context's $config prop

tng-988