### PR TITLE
feat: make use of fetchByFilter's customFilter

### DIFF
--- a/fsxa.config.ts
+++ b/fsxa.config.ts
@@ -1,3 +1,5 @@
+import { CustomFilter } from 'fsxa-api/dist/types'
+
 export default {
   devMode: false,
   defaultLocale: 'de_DE',
@@ -9,5 +11,18 @@ export default {
     loader: '~/components/fsxa/Loader',
     page404: '~/components/fsxa/Page404'
   },
-  customRoutes: '~/customRoutes'
+  customRoutes: '~/customRoutes',
+  customFilter: ((items) =>
+    items.filter((item) => {
+      if (typeof item === 'object' && 'data' in (item as object)) {
+        const publishAt: string | undefined = (item as Record<'data', any>).data
+          .tt_publish_at
+        const published =
+          !publishAt || new Date(publishAt).getTime() - Date.now() <= 0
+
+        return published
+      }
+
+      return true
+    })) as CustomFilter
 }


### PR DESCRIPTION
This is just an example implementation of the new customFilter that doesn't make any real world sense.
The problem is that the function's explicit logic is highly database depending.
If anyone knows a good general use for demo purposes , feel free to leave a comment.