### PR TITLE
feat(links): consume new caas-mapper structure…

### DIFF
--- a/components/fsxa/richtext/Link.tsx
+++ b/components/fsxa/richtext/Link.tsx
@@ -1,40 +1,58 @@
+import type { Link as RichTextLink, Reference, CaaSApi_Option } from 'fsxa-api'
 import { FSXABaseRichTextElement } from 'fsxa-pattern-library'
 import { Component } from 'vue-property-decorator'
 
-export type Data = {
-  type: 'internal_link'
+export interface InternalLink extends RichTextLink {
+  template: 'internal_link'
   data: {
-    lt_link: {
-      value: {
-        identifier: string
-      }
-    }
+    lt_link: Reference
+    lt_text: string
   }
 }
+
+export interface ExternalLink extends RichTextLink {
+  template: 'external_link'
+  data: {
+    lt_url: string
+    lt_text: string
+    lt_link_behavior: CaaSApi_Option
+  }
+}
+
 @Component({
   name: 'RichTextLink'
 })
-class Link extends FSXABaseRichTextElement<Data> {
+class Link extends FSXABaseRichTextElement<InternalLink | ExternalLink> {
   render() {
-    return (
-      <a
-        class="underline"
-        href={
-          this.data.type === 'internal_link'
-            ? this.getUrlByPageId(this.data.data.lt_link.value.identifier) ||
-              '#'
-            : '#'
-        }
-        onClick={(event) => {
-          event.preventDefault()
-          this.triggerRouteChange({
-            pageId: this.data.data.lt_link.value.identifier
-          })
-        }}
-      >
-        {this.renderContent()}
-      </a>
-    )
+    switch (this.data.template) {
+      case 'internal_link':
+        return (
+          <a
+            class="underline"
+            href={
+              this.getUrlByPageId(this.data.data.lt_link.referenceId) || '#'
+            }
+            onClick={(event) => {
+              event.preventDefault()
+              this.triggerRouteChange({
+                pageId: (this.data as InternalLink).data.lt_link.referenceId
+              })
+            }}
+          >
+            {this.renderContent()}
+          </a>
+        )
+      case 'external_link':
+        return (
+          <a
+            class="underline"
+            href={this.data.data.lt_url || '#'}
+            target={this.data.data.lt_link_behavior.identifier}
+          >
+            {this.renderContent()}
+          </a>
+        )
+    }
   }
 }
 export default Link

--- a/docs/modules/ROOT/pages/components/FSXABaseRichTextElement.adoc
+++ b/docs/modules/ROOT/pages/components/FSXABaseRichTextElement.adoc
@@ -22,7 +22,7 @@ To use this base component a new class has to be created which extends the `FSXA
 class Component extends FSXABaseRichTextElement {}
 ----
 
-If you want to have type support for your data you can provide an interface and pass it as an generic like here the `Data` interface.
+If you want to have type support for your data you can provide an interface and pass it as an generic like here the `Data` interface or extend the `Link` interface in case of Links.
 
 [source,javascript]
 ----
@@ -34,7 +34,7 @@ class Component extends FSXABaseRichTextElement<Data> {}
 
 === `data` - Object
 
-Returns all available data attributes, for example the `data-fs-style` to determinate the styling.
+Returns all available data attributes, for example the `data-fs-style` to determinate the styling, respectively this is a `Link` and contains nested data that is maintained in FirstSpirit.
 
 === `content` - Array
 


### PR DESCRIPTION
of `Link`s in `RichTextElement`s

TNG-1047